### PR TITLE
README: fix project links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # wf-install
 
 ## `install.sh`
-`install.sh` is a script to install and configure [Wayfire](wayfire.org) and related programs like [wf-shell](https://github.com/WayfireWM/wayfire).
+`install.sh` is a script to install and configure [Wayfire](https://wayfire.org) and related programs like [wf-shell](https://github.com/WayfireWM/wf-shell).
 
 The general usage is:
 


### PR DESCRIPTION
- Wayfire link needed "https://", otherwise GitHub treats it as a
relative link inside the repository

- wf-shell link was leading to the Wayfire repo instead of the wf-shell
repo