### PR TITLE
startwayfire: Set XDG_DATA_DIRS if unset

### DIFF
--- a/start_wayfire.sh.in
+++ b/start_wayfire.sh.in
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# if $XDG_DATA_DIRS is not set, set it to the spec recommended value
+[ -z "$XDG_DATA_DIRS" ] && export XDG_DATA_DIRS="/usr/local/share:/usr/share"
+
 # path for wf-config and wlroots
 LD_LIBRARY_PATH=$LD_LIBRARY_PATH
 # path is needed for wf-shell clients


### PR DESCRIPTION
According to the xdg spec, "If XDG_DATA_DIRS is either not set or empty,
a value equal to /usr/local/share/:/usr/share/ should be used.". Without
this, if XDG_DATA_DIRS is unset, it may prevent gtk applications from starting.

Fixes #13 