### PR TITLE
install.sh: Support tilde in prefix

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -45,6 +45,7 @@ while true; do
         -p|--prefix)
             shift
             PREFIX=$1
+            eval PREFIX=$PREFIX
             ;;
         --system-wlroots)
             USE_SYSTEM_WLROOTS=enabled


### PR DESCRIPTION
Without this, the script tries to use sudo for paths owned by user.