### PR TITLE
install.sh Support single leading tilde in prefix (without using eval, replacement for #24)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -46,6 +46,9 @@ while true; do
         -p|--prefix)
             shift
             PREFIX=$1
+            if test "x$PREFIX" != "x${PREFIX#\~/}"; then
+                PREFIX="$HOME/${PREFIX#\~/}"
+            fi
             ;;
         --system-wlroots)
             USE_SYSTEM_WLROOTS=enabled


### PR DESCRIPTION
See #24 for details; this method does not use eval and shouldn't have problems with other special characters than `~` (it doesn't support `~username` or a lone `~`, adding those would be easy but they are unlikely to be used in practice.