### PR TITLE
Move # Dependencies to the top and add more dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # wf-install
 
+## Dependencies
+
+The following is a list of dependencies needed on Ubuntu, similar lists are required on other distributions. The last one is only needed if you want to install WCM.
+
+`sudo apt install git meson python3-pip pkg-config libwayland-dev autoconf libtool libffi-dev libxml2-dev libegl1-mesa-dev libgles2-mesa-dev libgbm-dev libinput-dev libxkbcommon-dev libpixman-1-dev xutils-dev xcb-proto python3-xcbgen libcairo2-dev libglm-dev libjpeg-dev libgtkmm-3.0-dev xwayland libdrm-dev libgirepository1.0-dev libsystemd-dev policykit-1 libx11-xcb-dev libxcb-xinput-dev libxcb-composite0-dev xwayland libasound2-dev libpulse-dev libseat-dev valac libdbusmenu-gtk3-dev libxkbregistry-dev`
+
 ## `install.sh`
 `install.sh` is a script to install and configure [Wayfire](https://wayfire.org) and related programs like [wf-shell](https://github.com/WayfireWM/wf-shell).
 
@@ -17,12 +23,6 @@ If you want to build the latest versions, use `--stream master`.
 For Wayfire and wf-shell, default configuration files will also be installed to `$XDG_CONFIG_HOME/wayfire.ini` or `~/.config/wayfire.ini`
 
 The script also has a few other options, which you can see by calling `./install.sh --help`
-
-## Dependencies
-
-The following is a list of dependencies needed on Ubuntu, similar lists are required on other distributions.
-
-`sudo apt install git meson python3-pip pkg-config libwayland-dev autoconf libtool libffi-dev libxml2-dev libegl1-mesa-dev libgles2-mesa-dev libgbm-dev libinput-dev libxkbcommon-dev libpixman-1-dev xutils-dev xcb-proto python3-xcbgen libcairo2-dev libglm-dev libjpeg-dev libgtkmm-3.0-dev xwayland libdrm-dev libgirepository1.0-dev libsystemd-dev policykit-1 libx11-xcb-dev libxcb-xinput-dev libxcb-composite0-dev xwayland libasound2-dev libpulse-dev`
 
 ## `update_build.sh`
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # wf-install
+This contains an install script called `install.sh`. It is a script to install and configure [Wayfire](https://wayfire.org) and related programs like [wf-shell](https://github.com/WayfireWM/wf-shell).
 
 ## Dependencies
 
@@ -7,7 +8,6 @@ The following is a list of dependencies needed on Ubuntu, similar lists are requ
 `sudo apt install git meson python3-pip pkg-config libwayland-dev autoconf libtool libffi-dev libxml2-dev libegl1-mesa-dev libgles2-mesa-dev libgbm-dev libinput-dev libxkbcommon-dev libpixman-1-dev xutils-dev xcb-proto python3-xcbgen libcairo2-dev libglm-dev libjpeg-dev libgtkmm-3.0-dev xwayland libdrm-dev libgirepository1.0-dev libsystemd-dev policykit-1 libx11-xcb-dev libxcb-xinput-dev libxcb-composite0-dev xwayland libasound2-dev libpulse-dev libseat-dev valac libdbusmenu-gtk3-dev libxkbregistry-dev`
 
 ## `install.sh`
-`install.sh` is a script to install and configure [Wayfire](https://wayfire.org) and related programs like [wf-shell](https://github.com/WayfireWM/wf-shell).
 
 The general usage is:
 

--- a/install.sh
+++ b/install.sh
@@ -166,7 +166,7 @@ ask_confirmation "Do you want to install wayfire-plugins-extra? [y/n]? "
 if [ "$yn" = Y ]; then
     check_download wayfire-plugins-extra
     cd "$BUILDROOT/wayfire-plugins-extra"
-    PKG_CONFIG_PATH="$PKG_CONFIG_PATH:${PREFIX}/${DEST_LIBDIR}/pkgconfig" meson build --prefix="${PREFIX}"
+    PKG_CONFIG_PATH="$PKG_CONFIG_PATH:${PREFIX}/${DEST_LIBDIR}/pkgconfig" meson setup build --prefix="${PREFIX}"
     ninja -C build
     $SUDO ninja -C build install
 fi
@@ -175,7 +175,7 @@ ask_confirmation "Do you want to install WCM, a graphical configuration tool for
 if [ "$yn" = Y ]; then
     check_download wcm
     cd "$BUILDROOT/wcm"
-    PKG_CONFIG_PATH="$PKG_CONFIG_PATH:${PREFIX}/${DEST_LIBDIR}/pkgconfig" meson build --prefix="${PREFIX}"
+    PKG_CONFIG_PATH="$PKG_CONFIG_PATH:${PREFIX}/${DEST_LIBDIR}/pkgconfig" meson setup build --prefix="${PREFIX}"
     ninja -C build
     $SUDO ninja -C build install
 fi


### PR DESCRIPTION
When running `./install.sh --prefix /opt/wayfire --stream 0.8.x`, it gives you errors about dependencies not listed, so I guessed I'll add those extra things. I also made it use `meson setup [options]` `meson [options]` as it is depracated.
I moved # Dependencies to the top so it will be visible that you have to install some dependencies without needing to scroll down in order to find out.