### PR TITLE
install.sh: Add the ability to use doas if it is present, instead of sudo

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -88,8 +88,14 @@ function ask_confirmation {
     done
 }
 
+# Check if we have doas, if we do, use it instead of sudo.
+if [[ -n "$(command -v doas)" ]]; then
+	SUDO=doas
+else
+	SUDO=sudo
+fi
+
 # Usually we use sudo, but if prefix is somewhere in ~/, we don't need sudo
-SUDO=sudo
 if [ -w "$PREFIX" ] || ! which sudo > /dev/null; then
     SUDO=
 fi


### PR DESCRIPTION
Some users may not use or even have sudo available to them, and because of this, the install script breaks trying to remove `startwayfire` or add it, I'm not too sure. But once I had sudo installed, the script worked fine. 