### PR TITLE
Add nlohmann-json3-dev to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This contains an install script called `install.sh`. It is a script to install a
 
 The following is a list of dependencies needed on Ubuntu, similar lists are required on other distributions. The last one is only needed if you want to install WCM.
 
-`sudo apt install git meson python3-pip pkg-config libwayland-dev autoconf libtool libffi-dev libxml2-dev libegl1-mesa-dev libgles2-mesa-dev libgbm-dev libinput-dev libxkbcommon-dev libpixman-1-dev xutils-dev xcb-proto python3-xcbgen libcairo2-dev libglm-dev libjpeg-dev libgtkmm-3.0-dev xwayland libdrm-dev libgirepository1.0-dev libsystemd-dev policykit-1 libx11-xcb-dev libxcb-xinput-dev libxcb-composite0-dev xwayland libasound2-dev libpulse-dev libseat-dev valac libdbusmenu-gtk3-dev libxkbregistry-dev libdisplay-info-dev hwdata`
+`sudo apt install git meson python3-pip pkg-config libwayland-dev autoconf libtool libffi-dev libxml2-dev libegl1-mesa-dev libgles2-mesa-dev libgbm-dev libinput-dev libxkbcommon-dev libpixman-1-dev xutils-dev xcb-proto python3-xcbgen libcairo2-dev libglm-dev libjpeg-dev libgtkmm-3.0-dev xwayland libdrm-dev libgirepository1.0-dev libsystemd-dev policykit-1 libx11-xcb-dev libxcb-xinput-dev libxcb-composite0-dev xwayland libasound2-dev libpulse-dev libseat-dev valac libdbusmenu-gtk3-dev libxkbregistry-dev libdisplay-info-dev nlohmann-json3-dev hwdata`
 
 ## `install.sh`
 


### PR DESCRIPTION
Installation atempt of 0.9.x on raspberry pi os throws following error

```
Run-time dependency nlohmann_json found: NO (tried pkgconfig)

meson.build:36:0: ERROR: Dependency "nlohmann_json" not found, tried pkgconfig
```

Updated readme dependencies accordingly.